### PR TITLE
Update allow connections

### DIFF
--- a/examples/connections/app.rb
+++ b/examples/connections/app.rb
@@ -19,7 +19,7 @@ puts "permitting connection from #{user}"
 @app.messaging.permit_connection(user)
 connections = @app.messaging.allowed_connections
 puts "your app allowed connections are:"
-connections.keys.each do |k|
+connections.each do |k|
   puts " - #{k}"
 end
 puts ""
@@ -29,7 +29,7 @@ puts "revoking connection from #{user}"
 @app.messaging.revoke_connection(user)
 connections = @app.messaging.allowed_connections
 puts "your app allowed connections are:"
-connections.keys.each do |k|
+connections.each do |k|
   puts " - #{k}"
 end
 puts ""
@@ -39,7 +39,7 @@ puts "permitting connection from #{user}"
 @app.messaging.permit_connection(user)
 connections = @app.messaging.allowed_connections
 puts "your app allowed connections are:"
-connections.keys.each do |k|
+connections.each do |k|
   puts " - #{k}"
 end
 puts ""

--- a/lib/acl.rb
+++ b/lib/acl.rb
@@ -14,11 +14,7 @@ module SelfSDK
     # Lists allowed connections.
     def list
       SelfSDK.logger.info "Listing allowed connections"
-      rules = {}
-      @messaging.list_acl_rules.each do |c|
-        rules[c['acl_source']] = DateTime.parse(c['acl_exp'])
-      end
-      rules
+      @messaging.list_acl_rules
     end
 
     # Allows incomming messages from the given identity.


### PR DESCRIPTION
From now on self messaging service will be returning the allowed connections a
a string list instead of an object array