### PR TITLE
Use the same storage folder for all examples

### DIFF
--- a/examples/authentication/app.rb
+++ b/examples/authentication/app.rb
@@ -9,6 +9,7 @@ SelfSDK.logger = Logger.new('/dev/null') if ENV.has_key?'NO_LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/

--- a/examples/authentication/blocking.rb
+++ b/examples/authentication/blocking.rb
@@ -9,6 +9,7 @@ SelfSDK.logger = Logger.new('/dev/null') if ENV.has_key?'NO_LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/

--- a/examples/authentication/subscription.rb
+++ b/examples/authentication/subscription.rb
@@ -9,6 +9,7 @@ SelfSDK.logger = Logger.new('/dev/null') if ENV.has_key?'NO_LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/

--- a/examples/connections/app.rb
+++ b/examples/connections/app.rb
@@ -9,6 +9,7 @@ SelfSDK.logger = Logger.new('/dev/null') if ENV.has_key?'NO_LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/

--- a/examples/dl_authentication/app.rb
+++ b/examples/dl_authentication/app.rb
@@ -7,6 +7,7 @@ SelfSDK.logger = Logger.new('/dev/null') if ENV.has_key?'NO_LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/

--- a/examples/dl_fact_request/app.rb
+++ b/examples/dl_fact_request/app.rb
@@ -7,6 +7,7 @@ SelfSDK.logger = Logger.new('/dev/null') if ENV.has_key?'NO_LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/

--- a/examples/fact_request/app.rb
+++ b/examples/fact_request/app.rb
@@ -9,6 +9,7 @@ SelfSDK.logger = Logger.new('/dev/null') if ENV.has_key?'NO_LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/

--- a/examples/fact_request/blocking.rb
+++ b/examples/fact_request/blocking.rb
@@ -9,6 +9,7 @@ SelfSDK.logger = Logger.new('/dev/null') if ENV.has_key?'NO_LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/

--- a/examples/intermediary_request/app.rb
+++ b/examples/intermediary_request/app.rb
@@ -9,6 +9,7 @@ SelfSDK.logger = Logger.new('/dev/null') if ENV.has_key?'NO_LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/

--- a/examples/qr_authentication/app.rb
+++ b/examples/qr_authentication/app.rb
@@ -7,6 +7,7 @@ SelfSDK.logger = Logger.new('/dev/null') if ENV.has_key?'NO_LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/

--- a/examples/qr_fact_request/app.rb
+++ b/examples/qr_fact_request/app.rb
@@ -7,6 +7,7 @@ SelfSDK.logger = Logger.new('/dev/null') if ENV.has_key?'NO_LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/

--- a/examples/web/authentication/app.rb
+++ b/examples/web/authentication/app.rb
@@ -20,6 +20,7 @@ class AuthExample < Sinatra::Base
     # You can point to a different environment by passing optional values to the initializer in
     # case you need to
     opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+    opts[:storage_dir] = "#{File.expand_path("..", "..", File.dirname(__FILE__))}/.self_storage"
 
     # Connect your app to Self network, get your connection details creating a new
     # app on https://developer.selfsdk.net/

--- a/examples/web/fact_request/app.rb
+++ b/examples/web/fact_request/app.rb
@@ -23,6 +23,7 @@ class AuthExample < Sinatra::Base
     # You can point to a different environment by passing optional values to the initializer in
     # case you need to
     opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+    opts[:storage_dir] = "#{File.expand_path("..", "..", File.dirname(__FILE__))}/.self_storage"
 
     # Connect your app to Self network, get your connection details creating a new
     # app on https://developer.selfsdk.net/

--- a/examples/web/intermediary_request/app.rb
+++ b/examples/web/intermediary_request/app.rb
@@ -23,6 +23,7 @@ class AuthExample < Sinatra::Base
     # You can point to a different environment by passing optional values to the initializer in
     # case you need to
     opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+    opts[:storage_dir] = "#{File.expand_path("..", "..", File.dirname(__FILE__))}/.self_storage"
 
     # Connect your app to Self network, get your connection details creating a new
     # app on https://developer.selfsdk.net/

--- a/examples/web/qr_authentication/app.rb
+++ b/examples/web/qr_authentication/app.rb
@@ -25,6 +25,7 @@ class AuthExample < Sinatra::Base
     # You can point to a different environment by passing optional values to the initializer in
     # case you need to
     opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+    opts[:storage_dir] = "#{File.expand_path("..", "..", File.dirname(__FILE__))}/.self_storage"
 
     # Connect your app to Self network, get your connection details creating a new
     # app on https://developer.joinself.com/

--- a/examples/web/qr_fact_request/app.rb
+++ b/examples/web/qr_fact_request/app.rb
@@ -25,6 +25,7 @@ class AuthExample < Sinatra::Base
     # You can point to a different environment by passing optional values to the initializer in
     # case you need to
     opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
+    opts[:storage_dir] = "#{File.expand_path("..", "..", File.dirname(__FILE__))}/.self_storage"
 
     # Connect your app to Self network, get your connection details creating a new
     # app on https://developer.selfsdk.net/


### PR DESCRIPTION
If you’re running through all the examples SDK will be creating a ./.storage_dir on each example folder, so if you go through different examples with the same account it will create different storage files.

This can cause problems when retrieving the messages from the server, as it will report its on a different history position.