### PR TITLE
Lock storage_file for writting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test.rb
 .idea
 coverage/*
 .bundle
+.self_storage

--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -367,6 +367,8 @@ module SelfSDK
 
     def process_incomming_message(input)
       message = SelfSDK::Messages.parse(input, self)
+      @offset = input.offset
+      write_offset(@offset)
 
       if @messages.include? message.id
         message.validate! @messages[message.id][:original_message]
@@ -378,8 +380,6 @@ module SelfSDK
         notify_observer(message)
       end
 
-      @offset = input.offset
-      write_offset(@offset)
     rescue StandardError => e
       p "Error processing incoming message #{input.to_json}"
       SelfSDK.logger.info e
@@ -434,6 +434,7 @@ module SelfSDK
 
     def write_offset(offset)
       File.open(@offset_file, 'wb') do |f|
+        f.flock(File::LOCK_EX)
         f.write([offset].pack('q'))
       end
     end


### PR DESCRIPTION
Locking storage_file prevents some programs to corrupt the storage file when they finish unexpectedly.