### PR TITLE
Bidirectional ACL checks

### DIFF
--- a/examples/dl_fact_request/app.rb
+++ b/examples/dl_fact_request/app.rb
@@ -29,7 +29,7 @@ end
 
 # Generate a DL code to authenticate
 url = @app.facts.generate_deep_link([:display_name], "https://my.test.com")
-p "Authenticate with selfsdk through #{url}"
+p "Request display name through #{url}"
 
 # Wait for some time
 sleep 100

--- a/lib/selfsdk.rb
+++ b/lib/selfsdk.rb
@@ -61,12 +61,12 @@ module SelfSDK
 
     # Provides access to SelfSDK::Services::Facts service
     def facts
-      @facts ||= SelfSDK::Services::Facts.new(@messaging_client, @client)
+      @facts ||= SelfSDK::Services::Facts.new(messaging, @client)
     end
 
     # Provides access to SelfSDK::Services::Authentication service
     def authentication
-      @authentication ||= SelfSDK::Services::Authentication.new(@messaging_client, @client)
+      @authentication ||= SelfSDK::Services::Authentication.new(messaging, @client)
     end
 
     # Provides access to SelfSDK::Services::Identity service

--- a/lib/services/auth.rb
+++ b/lib/services/auth.rb
@@ -15,7 +15,8 @@ module SelfSDK
       #
       # @return [SelfSDK::Services::Authentication] authentication service.
       def initialize(messaging, client)
-        @messaging = messaging
+        @messaging = messaging.client
+        @messaging_service = messaging
         @client = client
       end
 
@@ -38,6 +39,7 @@ module SelfSDK
       #  @return [String, String] conversation id or encoded body.
       def request(selfid, opts = {}, &block)
         SelfSDK.logger.info "authenticating #{selfid}"
+        raise "You're not permitting connections from #{selfid}" unless @messaging_service.is_permitted?(selfid)
 
         req = SelfSDK::Messages::AuthenticationReq.new(@messaging)
         req.populate(selfid, opts)

--- a/lib/services/facts.rb
+++ b/lib/services/facts.rb
@@ -17,7 +17,8 @@ module SelfSDK
       #
       # @return [SelfSDK::Services::Facts] facts service.
       def initialize(messaging, client)
-        @messaging = messaging
+        @messaging = messaging.client
+        @messaging_service = messaging
         @client = client
       end
 
@@ -40,6 +41,7 @@ module SelfSDK
       #  @return [Object] SelfSDK:::Messages::FactRequest
       def request(selfid, facts, opts = {}, &block)
         SelfSDK.logger.info "authenticating #{selfid}"
+        raise "You're not permitting connections from #{selfid}" unless @messaging_service.is_permitted?(selfid)
 
         req = SelfSDK::Messages::FactRequest.new(@messaging)
         req.populate(selfid, prepare_facts(facts), opts)

--- a/lib/services/messaging.rb
+++ b/lib/services/messaging.rb
@@ -44,6 +44,15 @@ module SelfSDK
         acl.list
       end
 
+      # Checks if you're permitting messages from a specific self identifier
+      # @return [Boolean] yes|no
+      def is_permitted?(id)
+        conns = allowed_connections
+        return true if conns.include? "*"
+        return true if conns.include? id
+        return false
+      end
+
       # Revokes incoming messages from the given identity.
       #
       # @param [String] selfid to be denied

--- a/test/sdk_test.rb
+++ b/test/sdk_test.rb
@@ -11,7 +11,7 @@ class SelfSDKTest < Minitest::Test
   describe "selfsdk" do
     let(:seed)    { "JDAiDNIZ0b7QOK3JNFp6ZDFbkhDk+N3NJh6rQ2YvVFI" }
     let(:app_id)  { "o9mpng9m2jv" }
-    let(:messaging_client) { double("messaging", device_id: "1") }
+    let(:messaging_client) { double("messaging", device_id: "1", list_acl_rules:["*"] ) }
     let(:app) do
       a = SelfSDK::App.new(app_id, seed, "", messaging_url: nil)
       a.messaging_client = messaging_client
@@ -51,6 +51,7 @@ class SelfSDKTest < Minitest::Test
       jwt = double("jwt", id: "appid")
       client = double("client", jwt: jwt)
       expect(app.messaging_client).to receive(:client).and_return(client)
+      expect(app.messaging_client).to receive(:jwt).and_return(jwt)
       res = JSON.parse(app.authentication.request("xxxxxxxx", cid: "uuid", jti: "uuid", request: false))
       payload = JSON.parse(Base64.urlsafe_decode64(res['payload']))
       assert_equal "appid", payload['iss']

--- a/test/services/auth_service_test.rb
+++ b/test/services/auth_service_test.rb
@@ -37,7 +37,13 @@ class SelfSDKTest < Minitest::Test
       expect(mm).to receive(:client).and_return(client)
       mm
     end
-    let(:service) { SelfSDK::Services::Authentication.new(messaging, client) }
+    let(:messaging_service) do
+      mm = double("messaging_service")
+      expect(mm).to receive(:client).and_return(messaging)
+      expect(mm).to receive(:is_permitted?).and_return(true)
+      mm
+    end
+    let(:service) { SelfSDK::Services::Authentication.new(messaging_service, client) }
     let(:response_input) { 'input' }
     let(:response) { double("response", input: response_input) }
     let(:identity) { { public_keys: [ { key: "pk1"} ] } }

--- a/test/services/facts_service_test.rb
+++ b/test/services/facts_service_test.rb
@@ -38,7 +38,13 @@ class SelfSDKTest < Minitest::Test
       expect(mm).to receive(:client).and_return(client)
       mm
     end
-    let(:service) { SelfSDK::Services::Facts.new(messaging, client) }
+    let(:messaging_service) do
+      mm = double("messaging_service")
+      expect(mm).to receive(:client).and_return(messaging)
+      expect(mm).to receive(:is_permitted?).and_return(true)
+      mm
+    end
+    let(:service) { SelfSDK::Services::Facts.new(messaging_service, client) }
     let(:response_input) { 'input' }
     let(:response) { double("response", input: response_input, uuid: cid, selfid: selfid) }
     let(:identity) { { public_keys: [ { key: "pk1"} ] } }


### PR DESCRIPTION
When I send a request to an identity, the system checks if that identity is permitting connections from my app, however, as it is a request expecting a response we should also check my app is permitting connections from that identity.