### PR TITLE
Make storage_dir mandatory on client initialization

### DIFF
--- a/examples/authentication/app.rb
+++ b/examples/authentication/app.rb
@@ -13,11 +13,11 @@ end if ENV.has_key?'LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
+storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/
-@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
 # Authenticate a user to your app.
 puts "Sending an authentication request to your device..."

--- a/examples/authentication/blocking.rb
+++ b/examples/authentication/blocking.rb
@@ -13,11 +13,11 @@ end if ENV.has_key?'LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
+storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/
-@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
 # Authenticate a user to your app.
 puts "Sending an authentication request to your device..."

--- a/examples/authentication/subscription.rb
+++ b/examples/authentication/subscription.rb
@@ -13,11 +13,11 @@ end if ENV.has_key?'LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
+storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/
-@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
 begin
   # Subscribe to authentication messages

--- a/examples/connections/app.rb
+++ b/examples/connections/app.rb
@@ -13,11 +13,11 @@ SelfSDK.logger = ::Logger.new($stdout).tap do |log|
   
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
+storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/
-@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
 puts "CONNECTIONS EXAMPLE"
 # Remove all existing connections

--- a/examples/dl_authentication/app.rb
+++ b/examples/dl_authentication/app.rb
@@ -11,11 +11,11 @@ end if ENV.has_key?'LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
+storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/
-@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
 # Register an observer for an authentication response
 @app.authentication.subscribe do |auth|

--- a/examples/dl_fact_request/app.rb
+++ b/examples/dl_fact_request/app.rb
@@ -11,11 +11,11 @@ end if ENV.has_key?'LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
+storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/
-@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
 # Register an observer for an information response
 @app.messaging.subscribe :fact_response do |res|

--- a/examples/fact_request/app.rb
+++ b/examples/fact_request/app.rb
@@ -13,11 +13,11 @@ end if ENV.has_key?'LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
+storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/
-@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
 # Request display_name and email_address to the specified user
 begin

--- a/examples/fact_request/blocking.rb
+++ b/examples/fact_request/blocking.rb
@@ -13,11 +13,11 @@ end if ENV.has_key?'LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
+storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/
-@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
 begin
   # Request display_name and email_address to the specified user

--- a/examples/intermediary_request/app.rb
+++ b/examples/intermediary_request/app.rb
@@ -13,11 +13,11 @@ end if ENV.has_key?'LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
+storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/
-@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
 # Even its a silly test lets check if the user's email is equal test@test.org
 # without ever leaking information about the user's fact.

--- a/examples/qr_authentication/app.rb
+++ b/examples/qr_authentication/app.rb
@@ -11,11 +11,11 @@ end if ENV.has_key?'LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
+storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/
-@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
 # Register an observer for an authentication response
 @app.authentication.subscribe do |auth|

--- a/examples/qr_fact_request/app.rb
+++ b/examples/qr_fact_request/app.rb
@@ -11,11 +11,11 @@ end if ENV.has_key?'LOGS'
 
 # You can point to a different environment by passing optional values to the initializer
 opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-opts[:storage_dir] = "#{File.expand_path("..", File.dirname(__FILE__))}/.self_storage"
+storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
 # Connect your app to Self network, get your connection details creating a new
 # app on https://developer.selfsdk.net/
-@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+@app = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
 # Register an observer for an information response
 @app.messaging.subscribe :fact_response do |res|

--- a/examples/web/authentication/app.rb
+++ b/examples/web/authentication/app.rb
@@ -22,11 +22,11 @@ class AuthExample < Sinatra::Base
     # You can point to a different environment by passing optional values to the initializer in
     # case you need to
     opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-    opts[:storage_dir] = "#{File.expand_path("..", "..", File.dirname(__FILE__))}/.self_storage"
+    storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
     # Connect your app to Self network, get your connection details creating a new
     # app on https://developer.selfsdk.net/
-    set :client, SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+    set :client, SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
   end
 
   # This is the default app endpoint which will be redirecting non-logged in users to sign_in

--- a/examples/web/fact_request/app.rb
+++ b/examples/web/fact_request/app.rb
@@ -25,11 +25,11 @@ class AuthExample < Sinatra::Base
     # You can point to a different environment by passing optional values to the initializer in
     # case you need to
     opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-    opts[:storage_dir] = "#{File.expand_path("..", "..", File.dirname(__FILE__))}/.self_storage"
+    storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
     # Connect your app to Self network, get your connection details creating a new
     # app on https://developer.selfsdk.net/
-    set :client, SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+    set :client, SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
   end
 
   # This is the default app endpoint which will be redirecting non-logged in users to facts

--- a/examples/web/intermediary_request/app.rb
+++ b/examples/web/intermediary_request/app.rb
@@ -25,11 +25,11 @@ class AuthExample < Sinatra::Base
     # You can point to a different environment by passing optional values to the initializer in
     # case you need to
     opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-    opts[:storage_dir] = "#{File.expand_path("..", "..", File.dirname(__FILE__))}/.self_storage"
+    storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
     # Connect your app to Self network, get your connection details creating a new
     # app on https://developer.selfsdk.net/
-    set :client, SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+    set :client, SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
   end
 
   # This is the default app endpoint which will be redirecting non-logged in users to facts

--- a/examples/web/qr_authentication/app.rb
+++ b/examples/web/qr_authentication/app.rb
@@ -27,11 +27,11 @@ class AuthExample < Sinatra::Base
     # You can point to a different environment by passing optional values to the initializer in
     # case you need to
     opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-    opts[:storage_dir] = "#{File.expand_path("..", "..", File.dirname(__FILE__))}/.self_storage"
+    storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
     # Connect your app to Self network, get your connection details creating a new
     # app on https://developer.joinself.com/
-    client = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+    client = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
     # let's subscribe to all authentication responses
     client.authentication.subscribe do |auth|

--- a/examples/web/qr_fact_request/app.rb
+++ b/examples/web/qr_fact_request/app.rb
@@ -27,11 +27,11 @@ class AuthExample < Sinatra::Base
     # You can point to a different environment by passing optional values to the initializer in
     # case you need to
     opts = ENV.has_key?('SELF_ENV') ? { env: ENV["SELF_ENV"] } : {}
-    opts[:storage_dir] = "#{File.expand_path("..", "..", File.dirname(__FILE__))}/.self_storage"
+    storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
 
     # Connect your app to Self network, get your connection details creating a new
     # app on https://developer.selfsdk.net/
-    client = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], opts)
+    client = SelfSDK::App.new(ENV["SELF_APP_ID"], ENV["SELF_APP_SECRET"], ENV["STORAGE_KEY"], storage_dir, opts)
 
     # let's subscribe to all fact responses
     client.facts.subscribe do |res|

--- a/lib/messages/base.rb
+++ b/lib/messages/base.rb
@@ -21,9 +21,9 @@ module SelfSDK
         msgs = []
         devices.each do |d|
           msgs << proto(d)
+          SelfSDK.logger.info "synchronously messaging to #{@to}:#{d}"
         end
         res = @messaging.send_and_wait_for_response(msgs, self)
-        SelfSDK.logger.info "synchronously messaging to #{@to}:#{@d}"
         res
       end
 
@@ -32,7 +32,7 @@ module SelfSDK
         res = []
         devices.each do |d|
           res << @messaging.send_message(proto(d))
-          SelfSDK.logger.info "asynchronously requested information to #{@to}:#{@d}"
+          SelfSDK.logger.info "asynchronously requested information to #{@to}:#{d}"
         end
         res.first
       end

--- a/lib/selfsdk.rb
+++ b/lib/selfsdk.rb
@@ -40,13 +40,13 @@ module SelfSDK
     # @param app_id [string] the app id.
     # @param app_key [string] the app api key provided by developer portal.
     # @param storage_key [string] the key to be used to encrypt persisted data.
+    # @param storage_dir [String] The folder where encryption sessions and settings will be stored
     # @param [Hash] opts the options to authenticate.
     # @option opts [String] :base_url The self provider url.
     # @option opts [String] :messaging_url The messaging self provider url.
     # @option opts [Bool] :auto_reconnect Automatically reconnects to websocket if connection is lost (defaults to true).
     # @option opts [Symbol] :env The environment to be used, defaults to ":production".
-    # @option opts [String] :storage_dir The folder where encryption sessions and settings will be stored
-    def initialize(app_id, app_key, storage_key, opts = {})
+    def initialize(app_id, app_key, storage_key, storage_dir, opts = {})
       SelfSDK.logger.debug "syncing ntp times #{SelfSDK::Time.now}"
       env = opts.fetch(:env, "")
 
@@ -56,7 +56,7 @@ module SelfSDK
         @messaging_client = MessagingClient.new(messaging_url,
                                                 @client,
                                                 storage_key,
-                                                storage_dir: opts.fetch(:storage_dir, MessagingClient::DEFAULT_STORAGE_DIR),
+                                                storage_dir: storage_dir,
                                                 auto_reconnect: opts.fetch(:auto_reconnect, MessagingClient::DEFAULT_AUTO_RECONNECT),
                                                 device_id: opts.fetch(:device_id, MessagingClient::DEFAULT_DEVICE))
       end

--- a/test/sdk_test.rb
+++ b/test/sdk_test.rb
@@ -15,7 +15,7 @@ class SelfSDKTest < Minitest::Test
     let(:app_id)  { "o9mpng9m2jv" }
     let(:messaging_client) { double("messaging", device_id: "1", list_acl_rules:["*"] ) }
     let(:app) do
-      a = SelfSDK::App.new(app_id, seed, "", messaging_url: nil)
+      a = SelfSDK::App.new(app_id, seed, "", "", messaging_url: nil)
       a.messaging_client = messaging_client
       a
     end
@@ -43,7 +43,7 @@ class SelfSDKTest < Minitest::Test
     end
 
     def test_init_with_custom_parameters
-      custom_app = SelfSDK::App.new(app_id, seed, "",base_url: "http://custom.self.net", messaging_url: nil)
+      custom_app = SelfSDK::App.new(app_id, seed, "", "", base_url: "http://custom.self.net", messaging_url: nil)
       assert_equal "http://custom.self.net", custom_app.client.self_url
       assert_equal app_id, custom_app.app_id
       assert_equal seed, custom_app.app_key


### PR DESCRIPTION
Due to the uncommon nature of the SDK needing to store state means having a default for this value can easily lead to nothing working and confusion. 
Forcing the user to declare it means they are more likely to question what it is/does and visit the documentation to find out.
