### PR TITLE
use custom domain for firebase dynamic links

### DIFF
--- a/lib/services/auth.rb
+++ b/lib/services/auth.rb
@@ -89,11 +89,11 @@ module SelfSDK
         body = @client.jwt.encode(request(selfid, opts))
 
         if @client.env.empty?
-          return "https://joinself.page.link/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app"
+          return "https://links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app"
         elsif @client.env == 'development'
-          return "https://joinself.page.link/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.dev"
+          return "https://links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.dev"
         end
-        "https://joinself.page.link/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.#{@client.env}"
+        "https://#{@client.env}.links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.#{@client.env}"
       end
 
       # Adds an observer for an authentication response

--- a/lib/services/facts.rb
+++ b/lib/services/facts.rb
@@ -116,11 +116,11 @@ module SelfSDK
         body = @client.jwt.encode(request(selfid, facts, opts))
 
         if @client.env.empty?
-          return "https://joinself.page.link/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app"
+          return "https://links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app"
         elsif @client.env == 'development'
-          return "https://joinself.page.link/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.dev"
+          return "https://links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.dev"
         end
-        "https://joinself.page.link/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.#{@client.env}"
+        "https://#{@client.env}.links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.#{@client.env}"
       end
 
       private


### PR DESCRIPTION
Firebase Dynamic Links do not support using the same URL prefix for multiple iOS apps/targets contained in the same Firebase project. 

### Solution: Using multiple (sub)domains

It works, if each iOS app uses its own (sub)domain for dynamic links. For instance, instead of using only pets.page.link for all targets, use cats.page.link for your first app target and dogs.page.link for your second app target. The crucial requirement for this is that each of your target's Associated Domains Entitlement contains only the (sub)domain(s) it should listen to.

### Custom domain

Additionally we're moving to custom sub-domains based on `joinself.com` to manage all dynamic links.

This will require changes both on `ios` and `android`

[Reference](https://stackoverflow.com/questions/41582867/firebase-dynamic-links-is-not-working-for-different-target-in-same-project-in-io/61208739#61208739)
