### PR TITLE
Allow non-ssl environments for file sharing

### DIFF
--- a/lib/chat/file_object.rb
+++ b/lib/chat/file_object.rb
@@ -75,7 +75,7 @@ module SelfSDK
       def upload(ciphertext)
         uri = URI.parse("#{@url}/v1/objects")
         https = Net::HTTP.new(uri.host, uri.port)
-        https.use_ssl = true
+        https.use_ssl = true if uri.scheme == "https"
         req = Net::HTTP::Post.new(uri.path)
         req["Authorization"] = "Bearer #{@token}"
         req.body = ciphertext.force_encoding("UTF-8")

--- a/selfsdk.gemspec
+++ b/selfsdk.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ed25519"
   s.add_dependency "eventmachine"
   s.add_dependency "faye-websocket"
-  s.add_dependency "google-protobuf"
+  s.add_dependency "google-protobuf", "~> 3.19"
   s.add_dependency "httparty"
   s.add_dependency "logger"
   s.add_dependency "net-ntp"


### PR DESCRIPTION
This error was displayed when trying to upload files on a non-ssl environment
```
connect_nonblock': SSL_connect returned=1 errno=0 state=error: wrong version number (OpenSSL::SSL::SSLError)
```

Net::HTTP was using `use_ssl` option by default which caused a mismatch with the url used.