### PR TITLE
Extract sources spec to a json file

### DIFF
--- a/lib/messages/fact.rb
+++ b/lib/messages/fact.rb
@@ -14,14 +14,11 @@ module SelfSDK
       end
 
       def parse(fact)
-        @name = SelfSDK::fact_name(fact[:fact])
-
-        @operator = ""
-        @operator = SelfSDK::operator(fact[:operator]) if fact[:operator]
-
+        @name = @messaging.source.normalize_fact_name! fact[:fact]
+        @operator = @messaging.source.normalize_operator!(fact[:operator])
         @sources = []
         fact[:sources]&.each do |s|
-          @sources << SelfSDK::source(s)
+          @sources << @messaging.source.normalize_source!(s)
         end
 
         @expected_value = fact[:expected_value] || ""

--- a/lib/messages/fact_response.rb
+++ b/lib/messages/fact_response.rb
@@ -43,7 +43,7 @@ module SelfSDK
       end
 
       def fact(name)
-        name = SelfSDK::fact_name(name)
+        name = @messaging.source.normalize_fact_name!(name)
         @facts.select{|f| f.name == name}.first
       end
 

--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -17,7 +17,7 @@ module SelfSDK
     DEFAULT_STORAGE_DIR="./.self_storage"
     ON_DEMAND_CLOSE_CODE=3999
 
-    attr_accessor :client, :jwt, :device_id, :ack_timeout, :timeout, :type_observer, :uuid_observer, :encryption_client
+    attr_accessor :client, :jwt, :device_id, :ack_timeout, :timeout, :type_observer, :uuid_observer, :encryption_client, :source
 
     # RestClient initializer
     #
@@ -47,6 +47,7 @@ module SelfSDK
       FileUtils.mkdir_p @storage_dir unless File.exist? @storage_dir
       @offset_file = "#{@storage_dir}/#{@jwt.id}:#{@device_id}.offset"
       @offset = read_offset
+      @source = SelfSDK::Sources.new("#{__dir__}/sources.json")
       migrate_old_storage_format
 
       unless options.include? :no_crypto
@@ -283,7 +284,7 @@ module SelfSDK
     end
 
     def subscribe(type, &block)
-      type = SelfSDK::message_type(type) if type.is_a? Symbol
+      type = @source.message_type(type) if type.is_a? Symbol
       @type_observer[type] = { block: block }
     end
 

--- a/lib/services/facts.rb
+++ b/lib/services/facts.rb
@@ -139,13 +139,13 @@ module SelfSDK
         fs = []
         facts.each do |f|
           fact = if f.is_a?(Hash)
-                  f
-                else
-                  { fact: f }
-                end
+                   f
+                 else
+                   { fact: f }
+                 end
           # validate_fact!(fact)
           fs << fact
-        end      
+        end
         fs
       end
 

--- a/lib/sources.json
+++ b/lib/sources.json
@@ -1,0 +1,56 @@
+{
+    "sources": {
+        "user_specified": [
+            "document_number",
+            "display_name",
+            "email_address",
+            "phone_number"
+        ],
+        "passport": [
+            "document_number",
+            "surname",
+            "given_names",
+            "date_of_birth",
+            "date_of_expiration",
+            "sex",
+            "nationality",
+            "country_of_issuance"
+        ],
+        "driving_license": [
+            "document_number",
+            "surname",
+            "given_names",
+            "date_of_birth",
+            "date_of_issuance",
+            "date_of_expiration",
+            "address",
+            "issuing_authority",
+            "place_of_birth"
+        ],
+        "identity_card": [
+            "document_number",
+            "surname",
+            "given_names",
+            "date_of_birth",
+            "date_of_expiration",
+            "sex",
+            "nationality",
+            "country_of_issuance"
+        ],
+        "twitter": [
+            "account_id",
+            "nickname"
+        ],
+        "linkedin": [
+            "account_id",
+            "nickname"
+        ],
+        "facebook": [
+            "account_id",
+            "nickname"
+        ],
+        "live": [
+            "selfie_verification"
+        ]
+    }
+}

--- a/test/messages/fact_test.rb
+++ b/test/messages/fact_test.rb
@@ -11,7 +11,7 @@ class SelfSDKTest < Minitest::Test
     let(:client) { double("client") }
     let(:jwt) { double("jwt") }
     let(:messaging) do
-      double("messaging", jwt: jwt, client: client)
+      double("messaging", jwt: jwt, client: client, source: SelfSDK::Sources.new("#{__dir__}/../../lib/sources.json"))
     end
     subject{ SelfSDK::Messages::Fact.new(messaging) }
 

--- a/test/services/auth_service_test.rb
+++ b/test/services/auth_service_test.rb
@@ -36,7 +36,7 @@ class SelfSDKTest < Minitest::Test
       mm
     end
     let(:messaging) do
-      mm = double("messaging")
+      mm = double("messaging", source: SelfSDK::Sources.new("#{__dir__}/../../lib/sources.json"))
       expect(mm).to receive(:client).and_return(client)
       mm
     end

--- a/test/services/facts_service_test.rb
+++ b/test/services/facts_service_test.rb
@@ -39,7 +39,7 @@ class SelfSDKTest < Minitest::Test
       mm
     end
     let(:messaging) do
-      mm = double("messaging")
+      mm = double("messaging", source: SelfSDK::Sources.new("#{__dir__}/../../lib/sources.json"))
       expect(mm).to receive(:client).and_return(client)
       mm
     end


### PR DESCRIPTION
This pr extracts the specification of sources and fact names to a json file instead of having it hardcoded.

Extracting sources / facts spec to a json file makes it trivial to add / remove facts and sources, and at the same time the specification can be shared between different sdks.

