### PR TITLE
Add expiration to attestations

### DIFF
--- a/lib/messages/fact_issue.rb
+++ b/lib/messages/fact_issue.rb
@@ -84,6 +84,7 @@ module SelfSDK
                  sub: @to,
                  iss: @from,
                  iat: SelfSDK::Time.now.strftime('%FT%TZ'),
+                 exp: (SelfSDK::Time.now + @exp_timeout).strftime('%FT%TZ'),
                  source: source,
                  verified: true,
                  facts: [ facts ] }


### PR DESCRIPTION
When facts are shared to a third party user, the expiration data can't be inferred from the fact enveloping it. This PR adds the expiration date to the attestation itself.