### PR TITLE
Support redirections

### DIFF
--- a/examples/connection/app.rb
+++ b/examples/connection/app.rb
@@ -34,7 +34,11 @@ end
 # This will open the exported qr.png with your default software,
 # manually open /tmp/qr.png and scan it with your device if it
 # does not work
-link = @app.chat.generate_connection_deep_link("https://www.google.com")
+
+# You can manage your redirection codes on your app management on the
+# developer portal
+redirection_code = "90d017d1"
+link = @app.chat.generate_connection_deep_link(redirection_code)
 p "Scan /tmp/qr.png with your device"
 `open /tmp/qr.png`
 p "or click this link \n\n #{link} \n\non your mobile phone"

--- a/examples/dl_authentication/app.rb
+++ b/examples/dl_authentication/app.rb
@@ -29,8 +29,12 @@ storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
   exit
 end
 
+# You can manage your redirection codes on your app management on the
+# developer portal
+redirection_code = "90d017d1"
+
 # Generate a DL code to authenticate
-url = @app.authentication.generate_deep_link("https://my.test.com")
+url = @app.authentication.generate_deep_link(redirection_code)
 p "Authenticate with selfsdk through #{url}"
 
 # Wait for some time

--- a/examples/dl_fact_request/app.rb
+++ b/examples/dl_fact_request/app.rb
@@ -31,8 +31,12 @@ storage_dir = "#{File.expand_path("..", File.dirname(__FILE__))}/self_storage"
   exit!
 end
 
-# Generate a DL code to authenticate
-url = @app.facts.generate_deep_link([:display_name], "https://my.test.com")
+# You can manage your redirection codes on your app management on the
+# developer portal
+redirection_code = "90d017d1"
+
+# Generate a DL code for a fact request
+url = @app.facts.generate_deep_link([:display_name], redirection_code)
 p "Request display name through #{url}"
 
 # Wait for some time

--- a/lib/jwt_service.rb
+++ b/lib/jwt_service.rb
@@ -93,6 +93,21 @@ module SelfSDK
       "#{payload}.#{signature}"
     end
 
+    def build_dynamic_link(body, env, callback)
+      base_url = "https://#{env}.links.joinself.com"
+      portal_url = "https://developer.#{env}.joinself.com"
+      apn = "com.joinself.app.#{env}"
+
+      if env.empty? || env == 'development'
+        base_url = "https://links.joinself.com"
+        portal_url = "https://developer.joinself.com"
+        apn = "com.joinself.app"
+      end
+      apn = "com.joinself.app.dev" if env == 'development'
+
+      "#{base_url}?link=#{portal_url}/callback/#{callback}%3Fqr=#{body}&apn=#{apn}"
+    end
+
     private
 
     def header

--- a/lib/selfsdk.rb
+++ b/lib/selfsdk.rb
@@ -55,6 +55,7 @@ module SelfSDK
 
       SelfSDK.logger.debug "syncing ntp times #{SelfSDK::Time.now}"
       env = opts.fetch(:env, "")
+      env = "" if env == "production"
 
       @client = RestClient.new(base_url(opts), app_id, app_key, env)
       messaging_url = messaging_url(opts)

--- a/lib/services/auth.rb
+++ b/lib/services/auth.rb
@@ -69,7 +69,7 @@ module SelfSDK
 
       # Generates a deep link to authenticate with self app.
       #
-      # @param callback [String] the url you'll be redirected if the app is not installed.
+      # @param callback [String] the callback identifier you'll be redirected to if the app is not installed.
       # @option opts [String] :selfid the user selfid you want to authenticate.
       # @option opts [String] :cid The unique identifier of the authentication request.
       #

--- a/lib/services/chat.rb
+++ b/lib/services/chat.rb
@@ -184,13 +184,7 @@ module SelfSDK
         body = @jwt.encode(body)
 
         env = @messaging.client.client.env
-        if env.empty?
-          return "https://links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app"
-        elsif env == 'development'
-          return "https://links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.dev"
-        end
-
-        "https://#{env}.links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.#{env}"
+        @jwt.build_dynamic_link(body, env, callback)
       end
 
       # Subscribes to a connection response

--- a/lib/services/facts.rb
+++ b/lib/services/facts.rb
@@ -84,7 +84,7 @@ module SelfSDK
       # Generates a deep link to authenticate with self app.
       #
       # @param facts [Array] a list of facts to be requested.
-      # @param callback [String] the url you'll be redirected if the app is not installed.
+      # @param callback [String] the callback identifier you'll be redirected to if the app is not installed.
       # @option opts [String] :selfid the user selfid you want to authenticate.
       # @option opts [String] :cid The unique identifier of the authentication request.
       #

--- a/lib/services/requester.rb
+++ b/lib/services/requester.rb
@@ -124,7 +124,7 @@ module SelfSDK
       # Generates a deep link to authenticate with self app.
       #
       # @param facts [Array] a list of facts to be requested.
-      # @param callback [String] the url you'll be redirected if the app is not installed.
+      # @param callback [String] the callback identifier you'll be redirected to if the app is not installed.
       # @option opts [String] :selfid the user selfid you want to authenticate.
       # @option opts [String] :cid The unique identifier of the authentication request.
       #
@@ -132,14 +132,9 @@ module SelfSDK
       def generate_deep_link(facts, callback, opts = {})
         opts[:request] = false
         selfid = opts.fetch(:selfid, "-")
-        body = @client.jwt.encode(request(selfid, facts, opts))
 
-        if @client.env.empty?
-          return "https://links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app"
-        elsif @client.env == 'development'
-          return "https://links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.dev"
-        end
-        "https://#{@client.env}.links.joinself.com/?link=#{callback}%3Fqr=#{body}&apn=com.joinself.app.#{@client.env}"
+        body = @client.jwt.encode(request(selfid, facts, opts))
+        @client.jwt.build_dynamic_link(body, @client.env, callback)
       end
 
       private


### PR DESCRIPTION
Dynamic link redirections will be managed through the developer portal from now on

This means from now on, a developer must create a redirection for an app, and use the generated unique identifier with the helpers generating dynamic links on the sdks.