### PR TITLE
Improvements on session management

### DIFF
--- a/lib/client.rb
+++ b/lib/client.rb
@@ -85,14 +85,17 @@ module SelfSDK
     def get(endpoint)
       res = nil
       loop do
-        res = HTTParty.get("#{@self_url}#{endpoint}", headers: {
-          'Content-Type' => 'application/json',
-          'Authorization' => "Bearer #{@jwt.auth_token}"
-        })
-        break if res.code != 503
+        begin
+          res = HTTParty.get("#{@self_url}#{endpoint}", headers: {
+            'Content-Type' => 'application/json',
+            'Authorization' => "Bearer #{@jwt.auth_token}"
+          })
+          break if res.code != 503
+        rescue StandardError => e
+        end
         sleep 2
       end
-      return res
+      res
     end
 
     # Lists all public keys stored on self for the given ID

--- a/lib/crypto.rb
+++ b/lib/crypto.rb
@@ -60,7 +60,6 @@ module SelfSDK
           end
           session_with_bob = get_outbound_session_with_bob(locks[session_file_name], r[:id], r[:device_id])
         rescue => e
-          require 'pry'; binding.pry
           ::SelfSDK.logger.warn("  there is a problem adding group participant #{r[:id]}:#{r[:device_id]}, skipping...")
           ::SelfSDK.logger.warn(e)
           next

--- a/lib/messages/message.rb
+++ b/lib/messages/message.rb
@@ -21,6 +21,9 @@ require_relative "connection_response"
 
 module SelfSDK
   module Messages
+    class UnmappedMessage < StandardError
+    end
+    
     def self.parse(input, messaging, original=nil)
       envelope = nil
       body = if input.is_a? String
@@ -84,7 +87,7 @@ module SelfSDK
         m = VoiceSummary.new(messaging)
         m.parse(body, envelope)
       else
-        raise StandardError.new("Invalid message type #{payload[:typ]}.")
+        raise UnmappedMessage.new("Invalid message type #{payload[:typ]}.")
       end
       return m
     end

--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -463,14 +463,20 @@ module SelfSDK
     end
 
     def parse_and_write_offset(input)
-      SelfSDK::Messages.parse(input, self)
-    ensure
+      msg = SelfSDK::Messages.parse(input, self)
       write_offset(input.offset)
+      # Avoid catching any other decryption errors.
+      msg
+    rescue SelfSDK::Messages::UnmappedMessage => e
+      # this is an ummapped message, let's ignore it but write the offset.
+      write_offset(input.offset)
+      nil
     end
 
     # Authenticates current client on the websocket server.
     def authenticate
       @auth_id = SecureRandom.uuid if @auth_id.nil?
+      @offset = read_offset
 
       SelfSDK.logger.info "authenticating"
 


### PR DESCRIPTION
This pull request introduces some improvements on cryptographic session management:

### Avoid writing offset on decryption exceptions
Prevents offset from being stored if the session pickle file has not been persisted, this could be potentially be causing BAD_MESSAGE_MAC issues when the user uses a future offset to retrieve messages from the server.

### Offset and reconnection
The offset used when a workflow for auto connect is followed was incorrect, it was using a previous offset, so all previously processed messages were reprocessed when a problem on the network happens.

### Thread safe session file storage
Session files were written without a thread safe approach, and this could be causing those files to become corrupted.

### Http requests retry logic
In some scenarios httparty will throw an exception when it is not able to reach the network, in those cases the request was ignored and the retry logic didn't take place. This is being addressed by catching the exception and retrying the request with a delay.

