### PR TITLE
Upgrade docker image to run on ruby 3.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.3-slim-buster
+FROM ruby:3.2.1-slim-buster
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git cmake build-essential && \

--- a/selfsdk.gemspec
+++ b/selfsdk.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.date = '2011-09-29'
   s.summary = 'joinself sdk'
-  s.authors = ["Aldgate Ventures"]
+  s.authors = ["Self Group Ltd."]
   s.homepage = "https://www.joinself.com/"
   s.files = [
     "lib/selfsdk.rb",


### PR DESCRIPTION
Updgrades docker version to run on top of ruby 3.2.1 instead of the old 2.7.3