### PR TITLE
Safe requests

### DIFF
--- a/lib/acl.rb
+++ b/lib/acl.rb
@@ -25,30 +25,43 @@ module SelfSDK
     def allow(id)
       @acl_rules << id
       SelfSDK.logger.info "Allowing connections from #{id}"
-      @messaging.add_acl_rule(@jwt.prepare(jti: SecureRandom.uuid,
-                                           cid: SecureRandom.uuid,
-                                           typ: 'acl.permit',
-                                           iss: @jwt.id,
-                                           sub: @jwt.id,
-                                           iat: (SelfSDK::Time.now - 5).strftime('%FT%TZ'),
-                                           exp: (SelfSDK::Time.now + 60).strftime('%FT%TZ'),
-                                           acl_source: id,
-                                           acl_exp: (SelfSDK::Time.now + 360_000).to_datetime.rfc3339))
+      payload = @jwt.prepare(jti: SecureRandom.uuid,
+                             cid: SecureRandom.uuid,
+                             typ: 'acl.permit',
+                             iss: @jwt.id,
+                             sub: @jwt.id,
+                             iat: (SelfSDK::Time.now - 5).strftime('%FT%TZ'),
+                             exp: (SelfSDK::Time.now + 60).strftime('%FT%TZ'),
+                             acl_source: id,
+                             acl_exp: (SelfSDK::Time.now + 360_000).to_datetime.rfc3339)
+
+      a = SelfMsg::Acl.new
+      a.id = SecureRandom.uuid
+      a.command = SelfMsg::AclCommandPERMIT
+      a.payload = payload
+
+      @messaging.send_message a
     end
 
     # Deny incomming messages from the given identity.
     def deny(id)
       @acl_rules.delete(id)
       SelfSDK.logger.info "Denying connections from #{id}"
-      @messaging.remove_acl_rule(@jwt.prepare(jti: SecureRandom.uuid,
-                                               cid: SecureRandom.uuid,
-                                               typ: 'acl.revoke',
-                                               iss: @jwt.id,
-                                               sub: @jwt.id,
-                                               iat: (SelfSDK::Time.now - 5).strftime('%FT%TZ'),
-                                               exp: (SelfSDK::Time.now + 60).strftime('%FT%TZ'),
-                                               acl_source: id,
-                                               acl_exp: (SelfSDK::Time.now + 360_000).to_datetime.rfc3339))
+      payload = @jwt.prepare(jti: SecureRandom.uuid,
+                             cid: SecureRandom.uuid,
+                             typ: 'acl.revoke',
+                             iss: @jwt.id,
+                             sub: @jwt.id,
+                             iat: (SelfSDK::Time.now - 5).strftime('%FT%TZ'),
+                             exp: (SelfSDK::Time.now + 60).strftime('%FT%TZ'),
+                             acl_source: id,
+                             acl_exp: (SelfSDK::Time.now + 360_000).to_datetime.rfc3339)
+
+      a = SelfMsg::Acl.new
+      a.id = SecureRandom.uuid
+      a.command = SelfMsg::AclCommandREVOKE
+      a.payload = payload
+      @messaging.send_message a
     end
   end
 end

--- a/lib/crypto.rb
+++ b/lib/crypto.rb
@@ -60,7 +60,6 @@ module SelfSDK
           end
           session_with_bob = get_outbound_session_with_bob(locks[session_file_name], r[:id], r[:device_id])
         rescue => e
-          require 'pry'; binding.pry
           ::SelfSDK.logger.warn("  there is a problem adding group participant #{r[:id]}:#{r[:device_id]}, skipping...")
           ::SelfSDK.logger.warn(e)
           next

--- a/lib/crypto.rb
+++ b/lib/crypto.rb
@@ -60,6 +60,7 @@ module SelfSDK
           end
           session_with_bob = get_outbound_session_with_bob(locks[session_file_name], r[:id], r[:device_id])
         rescue => e
+          require 'pry'; binding.pry
           ::SelfSDK.logger.warn("  there is a problem adding group participant #{r[:id]}:#{r[:device_id]}, skipping...")
           ::SelfSDK.logger.warn(e)
           next

--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -257,6 +257,13 @@ module SelfSDK
           @acks[uuid][:waiting]
         end
       end
+
+      # response has timed out
+      if @acks[uuid][:timed_out]
+        SelfSDK.logger.info "acknowledgement response timed out re-sending message #{uuid}"
+        return send_message(msg)
+      end
+
       SelfSDK.logger.info "acknowledged #{uuid}"
       true
     ensure
@@ -378,6 +385,7 @@ module SelfSDK
           SelfSDK.logger.info "[#{uuid}] message response timed out"
           list[uuid][:waiting] = false
           list[uuid][:waiting_cond].broadcast
+          list[uuid][:timed_out] = true
         end
       end
     end

--- a/test/messaging_test.rb
+++ b/test/messaging_test.rb
@@ -22,18 +22,6 @@ class SelfSDKTest < Minitest::Test
       SelfSDK::MessagingClient.new("", client, "", storage_dir: storage_dir, ws: ws, no_crypto: true)
     end
 
-    def test_share_information
-      expect(ws).to receive(:send) do |msg|
-        input = SelfMsg::Message.new(data: msg.pack('c*'))
-        jwt = JSON.parse(input.ciphertext, symbolize_names: true)
-        payload = JSON.parse(messaging_client.jwt.decode(jwt[:payload]), symbolize_names: true)
-        assert_equal body, payload
-        messaging_client.stop
-      end
-
-      messaging_client.share_information("john", "john_device", body)
-    end
-
     def test_notify_observer_type
       messaging_client.type_observer[SelfSDK::Messages::FactResponse::MSG_TYPE] = {block: Proc.new do |res|
         assert_equal res.typ, SelfSDK::Messages::FactResponse::MSG_TYPE

--- a/test/services/messaging_service_test.rb
+++ b/test/services/messaging_service_test.rb
@@ -28,23 +28,36 @@ class SelfSDKTest < Minitest::Test
       let(:devices) { ["1", "2"]}
 
       def test_permit_connection
+        allow(SecureRandom).to receive(:uuid).and_return('uuid') 
         expect(jwt).to receive(:id).and_return(appid).at_least(:once)
         expect(jwt).to receive(:prepare).at_least(:once) do |arg|
           assert_equal arg[:iss], appid
           assert_equal arg[:acl_source], selfid
         end.and_return(json_body)
-        expect(messaging).to receive(:add_acl_rule).with(json_body).and_return(true).once
+
+        expect(messaging).to receive(:send_message).with(->(input) {
+          input.id == "uuid" &&
+          input.command == SelfMsg::AclCommandPERMIT &&
+          input.payload == json_body
+        }).and_return(true).once
         req = service.permit_connection(selfid)
         assert_equal true, req
       end
 
       def test_revoke_connection
+        allow(SecureRandom).to receive(:uuid).and_return('uuid') 
+
         expect(jwt).to receive(:id).and_return(appid).at_least(:once)
         expect(jwt).to receive(:prepare).at_least(:once) do |arg|
           assert_equal arg[:iss], appid
           assert_equal arg[:acl_source], selfid
         end.and_return(json_body)
-        expect(messaging).to receive(:remove_acl_rule).with(json_body).and_return(true).once
+
+        expect(messaging).to receive(:send_message).with(->(input) {
+          input.id == "uuid" &&
+          input.command == SelfMsg::AclCommandREVOKE &&
+          input.payload == json_body
+        }).and_return(true).once
         req = service.revoke_connection(selfid)
         assert_equal true, req
       end


### PR DESCRIPTION
Improvements:
- [x] Improves crypto and messaging logging
- [x] Improves http client requests with retries based on a better error reporting described on https://github.com/joinself/self-ruby-sdk/issues/275
- [x] Adds some extra offset improvements to messaging client.
- [x] Resends a message that has not been acknowledged within the predefined timeout
- [x] Reduce the log level to debug