### PR TITLE
Add support for rid and cid modifiers

### DIFF
--- a/lib/chat/message.rb
+++ b/lib/chat/message.rb
@@ -5,13 +5,15 @@
 module SelfSDK
   module Chat
     class Message
-      attr_accessor :gid, :body, :from, :payload, :recipients, :objects
+      attr_accessor :gid, :body, :from, :payload, :recipients, :objects, :rid, :cid
 
       def initialize(chat, recipients, payload, auth_token, self_url)
         @chat = chat
         @recipients = recipients
         @recipients = [@recipients] if @recipients.is_a? String
         @gid = payload[:gid] if payload.key? :gid
+        @rid = payload[:rid] if payload.key? :rid
+        @cid = payload[:cid] if payload.key? :cid
         @payload = payload
         @payload[:jti] = SecureRandom.uuid unless @payload.include?(:jti)
         @body = @payload[:msg]
@@ -69,8 +71,7 @@ module SelfSDK
       # @param body [string] the new message body.
       #
       # @return ChatMessage
-      def respond(body)
-        opts = {}
+      def respond(body, opts = {})
         opts[:aud] = @payload[:gid] if @payload.key? :gid
         opts[:gid] = @payload[:gid] if @payload.key? :gid
         opts[:rid] = @payload[:jti]

--- a/lib/services/chat.rb
+++ b/lib/services/chat.rb
@@ -35,6 +35,8 @@ module SelfSDK
         payload[:gid] = opts[:gid] if opts.key? :gid
         payload[:rid] = opts[:rid] if opts.key? :rid
         payload[:objects] = opts[:objects] if opts.key? :objects
+        payload[:cid] = opts[:cid] if opts.key? :cid
+        payload[:data] = opts[:data] if opts.key? :data
 
         m = SelfSDK::Chat::Message.new(self, recipients, payload, @jwt.auth_token, @self_url)
         _req = send(m.recipients, m.payload)


### PR DESCRIPTION
When sending chat messages a developer may need to modify or have access to `cid` and `rid` properties.