### PR TITLE
Parse unknown message types

### DIFF
--- a/lib/messages/message.rb
+++ b/lib/messages/message.rb
@@ -18,6 +18,7 @@ require_relative "voice_busy"
 require_relative "voice_summary"
 require_relative "document_sign_resp"
 require_relative "connection_response"
+require_relative "unknown"
 
 module SelfSDK
   module Messages
@@ -87,7 +88,8 @@ module SelfSDK
         m = VoiceSummary.new(messaging)
         m.parse(body, envelope)
       else
-        raise UnmappedMessage.new("Invalid message type #{payload[:typ]}.")
+        m = Unknown.new(messaging)
+        m.parse(body, envelope)
       end
       return m
     end

--- a/lib/messages/unknown.rb
+++ b/lib/messages/unknown.rb
@@ -1,0 +1,29 @@
+# Copyright 2020 Self Group Ltd. All Rights Reserved.
+
+# frozen_string_literal: true
+
+require 'self_msgproto'
+require_relative 'base'
+require_relative '../ntptime'
+
+module SelfSDK
+  module Messages
+    class Unknown < Base
+      def parse(input, envelope=nil)
+        @input = input
+        @payload = get_payload input
+        @id = @payload[:cid]
+        @from = @payload[:iss]
+        @to = @payload[:sub]
+        @audience = payload[:aud]
+        @expires = @payload[:exp]
+        @typ = @payload[:typ]
+
+        if envelope
+          issuer = envelope.sender.split(":")
+          @from_device = issuer.last
+        end
+      end
+    end
+  end
+end

--- a/selfsdk.gemspec
+++ b/selfsdk.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |s|
     "lib/messages/document_sign_resp.rb",
     "lib/messages/connection_request.rb",
     "lib/messages/connection_response.rb",
+    "lib/messages/unknown.rb",
     "lib/services/auth.rb",
     "lib/services/facts.rb",
     "lib/services/requester.rb",


### PR DESCRIPTION
Instead of raising an exception when a message type is not known map the message to a specific generic message named "unknown".