### PR TITLE
Add 'public' field to Chat Message Attached Objects

### DIFF
--- a/lib/chat/file_object.rb
+++ b/lib/chat/file_object.rb
@@ -74,12 +74,14 @@ module SelfSDK
       end
 
       def to_payload
+        k = build_key(@key, @nonce)
         {
           name: @name,
           link: @link,
-          key: build_key(@key, @nonce),
+          key: k,
           mime: @mime,
-          expires: @expires
+          expires: @expires,
+          public: (k == "")
         }
       end
 


### PR DESCRIPTION
### Description:
In order to accommodate the recent changes in the mobile app, we've introduced a new field `public` in the payload for chat message attached objects. This field is a boolean that will help us determine if the attached file object is public or not.

